### PR TITLE
Cache last event to improve heartbeat performance

### DIFF
--- a/aw_server/api.py
+++ b/aw_server/api.py
@@ -178,7 +178,7 @@ class ServerAPI:
                 if merged is not None:
                     # Heartbeat was merged into last_event
                     logger.debug("Received valid heartbeat, merging. (bucket: {})".format(bucket_id))
-                    self.db[bucket_id].replace_last(merged)
+                    self.db[bucket_id].replace(last_event.id, merged)
                     last_event_cache[bucket_id] = merged
                     return merged
                 else:


### PR DESCRIPTION
My aw-server instance is taking a bit too much CPU for my taste. This was an attempt at alleviating a database query that could easily be cached.

This should probably not make it into v0.7