### PR TITLE
disabled JSON pretty printing when not in testing mode

### DIFF
--- a/aw_server/server.py
+++ b/aw_server/server.py
@@ -53,6 +53,9 @@ def _start(storage_method, host, port, testing=False):
     # See: https://flask-cors.readthedocs.org/en/latest/
     CORS(app, resources={r"/api/*": {"origins": origins}})
 
+    # Only pretty-print JSON if in testing mode (because of performance)
+    app.config["JSONIFY_PRETTYPRINT_REGULAR"] = testing
+
     db = Datastore(storage_method, testing=testing)
     app.api = ServerAPI(db=db, testing=testing)
     app.run(debug=testing, host=host, port=port, request_handler=FlaskLogHandler, use_reloader=False)


### PR DESCRIPTION
Fixes https://github.com/ActivityWatch/activitywatch/issues/133

For whatever reason, it doesn't seem to work though. I've been testing it out with curl, and the JSON still looks pretty to me, despite trying to manually set the config option to False.