### PR TITLE
Filter out events from the future

### DIFF
--- a/aw_server/rest.py
+++ b/aw_server/rest.py
@@ -4,7 +4,7 @@ import json
 from flask import request, Blueprint, jsonify
 from flask_restplus import Api, Resource, fields
 import iso8601
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from aw_core import schema
 from aw_core.models import Event
@@ -176,6 +176,10 @@ class EventsResource(Resource):
             events = [Event(**e) for e in data]
         else:
             raise BadRequest("Invalid POST data", "")
+
+        events = [e for e in events if e.timestamp + e.duration < datetime.now(tz=timezone.utc)]
+        if len(events) == 0:
+            raise BadRequest("Invalid Event data - event data reaches into the future", "")
 
         event = app.api.create_events(bucket_id, events)
         return event.to_json_dict() if event else None, 200

--- a/aw_server/rest.py
+++ b/aw_server/rest.py
@@ -4,7 +4,7 @@ import json
 from flask import request, Blueprint, jsonify
 from flask_restplus import Api, Resource, fields
 import iso8601
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 
 from aw_core import schema
 from aw_core.models import Event
@@ -176,10 +176,6 @@ class EventsResource(Resource):
             events = [Event(**e) for e in data]
         else:
             raise BadRequest("Invalid POST data", "")
-
-        events = [e for e in events if e.timestamp + e.duration < datetime.now(tz=timezone.utc)]
-        if len(events) == 0:
-            raise BadRequest("Invalid Event data - event data reaches into the future", "")
 
         event = app.api.create_events(bucket_id, events)
         return event.to_json_dict() if event else None, 200

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -222,18 +222,5 @@ def test_midnight_heartbeats(client, bucket):
     assert len(recv_events_after_midnight) == int(len(recv_events_merged) / 2)
 
 
-def test_filter_future_events(client, bucket):
-    future_start = datetime.now(tz=timezone.utc) + timedelta(minutes=1)
-    future_events = _create_periodic_events(100, start=future_start, delta=timedelta(minutes=1))
-
-    #All events take place in the future, so an exception will be raised
-    with pytest.raises(Exception):
-        client.send_events(bucket, future_events)
-
-    recv_events = client.get_events(bucket, limit=-1)
-
-    assert len(recv_events) == 0
-
-
 if __name__ == "__main__":
     pytest.main()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -222,5 +222,15 @@ def test_midnight_heartbeats(client, bucket):
     assert len(recv_events_after_midnight) == int(len(recv_events_merged) / 2)
 
 
+def test_filter_future_events(client, bucket):
+    now = datetime.now(tz=timezone.utc)
+    future_events = _create_periodic_events(100, start=now, delta=timedelta(minutes=1))
+
+    client.send_events(bucket, future_events)
+    recv_events = client.get_events(bucket, limit=-1)
+
+    assert len(recv_events) == 0
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -161,7 +161,7 @@ def test_send_event(client, bucket):
 
 
 def test_send_events(client, bucket):
-    events = _create_periodic_events(2)
+    events = _create_periodic_events(2, start=datetime.now(tz=timezone.utc) - timedelta(days=1))
 
     client.send_events(bucket, events)
     recv_events = client.get_events(bucket)
@@ -171,7 +171,7 @@ def test_send_events(client, bucket):
 
 
 def test_get_events_interval(client, bucket):
-    start_dt = datetime.now(tz=timezone.utc)
+    start_dt = datetime.now(tz=timezone.utc) - timedelta(days=2)
     delta = timedelta(hours=1)
     events = _create_periodic_events(1000, delta=delta, start=start_dt)
 
@@ -185,7 +185,7 @@ def test_get_events_interval(client, bucket):
 
 
 def test_store_many_events(client, bucket):
-    events = _create_periodic_events(1000)
+    events = _create_periodic_events(1000, start=datetime.now(tz=timezone.utc) - timedelta(days=50))
 
     client.send_events(bucket, events)
     recv_events = client.get_events(bucket, limit=-1)
@@ -195,9 +195,9 @@ def test_store_many_events(client, bucket):
 
 
 def test_midnight(client, bucket):
-    now = datetime.now()
-    midnight = now.replace(hour=23, minute=50)
-    events = _create_periodic_events(100, start=midnight, delta=timedelta(minutes=1))
+    start_dt = datetime.now() - timedelta(days=1)
+    midnight = start_dt.replace(hour=23, minute=50)
+    events = _create_periodic_events(100, start=start_dt, delta=timedelta(minutes=1))
 
     client.send_events(bucket, events)
     recv_events = client.get_events(bucket, limit=-1)
@@ -223,10 +223,13 @@ def test_midnight_heartbeats(client, bucket):
 
 
 def test_filter_future_events(client, bucket):
-    now = datetime.now(tz=timezone.utc)
-    future_events = _create_periodic_events(100, start=now, delta=timedelta(minutes=1))
+    future_start = datetime.now(tz=timezone.utc) + timedelta(minutes=1)
+    future_events = _create_periodic_events(100, start=future_start, delta=timedelta(minutes=1))
 
-    client.send_events(bucket, future_events)
+    #All events take place in the future, so an exception will be raised
+    with pytest.raises(Exception):
+        client.send_events(bucket, future_events)
+
     recv_events = client.get_events(bucket, limit=-1)
 
     assert len(recv_events) == 0

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -171,7 +171,7 @@ def test_send_events(client, bucket):
 
 
 def test_get_events_interval(client, bucket):
-    start_dt = datetime.now(tz=timezone.utc) - timedelta(days=2)
+    start_dt = datetime.now(tz=timezone.utc) - timedelta(days=50)
     delta = timedelta(hours=1)
     events = _create_periodic_events(1000, delta=delta, start=start_dt)
 
@@ -205,7 +205,7 @@ def test_midnight(client, bucket):
 
 
 def test_midnight_heartbeats(client, bucket):
-    now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=timezone.utc) - timedelta(days=1)
     midnight = now.replace(hour=23, minute=50)
     events = _create_periodic_events(20, start=midnight, delta=timedelta(minutes=1))
 


### PR DESCRIPTION
This implements one of the fixes requested here: https://github.com/ActivityWatch/activitywatch/issues/153

"Add a check in aw-server that incoming events don't stretch into the future."

Any events in the POST data whose timestamp + duration is in the future compared to a datetime.now() invoked in the POST method will not be sent to the datastore. If there are no valid Events that pass this filter, a BadRequest exception is raised.

I added a new test to verify that this works. I also changed the starting point of many of the existing tests, as previously they were sending events with timestamps in the future that were being filtered out and causing the tests to fail. All the tests are still passing with this change.

Let me know what you think of this approach. Thanks!