### PR TITLE
Added dat:// protocol as allowed CORS origin

### DIFF
--- a/aw_server/server.py
+++ b/aw_server/server.py
@@ -46,7 +46,7 @@ def static_js(path):
 # Only to be called from aw_server.main function!
 def _start(storage_method, host, port, testing=False):
     # TODO: This should probably be more specific
-    origins = "moz-extension://*"
+    origins = ["moz-extension://*", "dat://"]
     if testing:
         # CORS won't be supported in non-testing mode until we fix our authentication
         logger.warning("CORS is enabled when ran in testing mode, don't store any sensitive data when running in testing mode!")


### PR DESCRIPTION
Hi! Thanks for ActivityWatch, I started using it a few days ago and find it useful.

I wanted to use the REST API to create my custom visualizations as frontend web apps (to run always locally), and noticed that I couldn't use the aw-server REST because of CORS issues. It would be nice if this would be an easy use case, even though I read that the HTTP interface shouldn't be used directly.

This PR adds a simple support for dat://* origins, similarly to moz-extension://*. Dat is a protocol used in [Beaker Browser](https://beakerbrowser.com/), which is a fantastic browser and really well suited for sharing local-only webapps, such as visualizations for AW.

dat:// is also supported in [Firefox](https://blog.mozilla.org/addons/2018/01/26/extensions-firefox-59/). When it comes to security, it's essentially like file:// (which should also be supported by aw-server?), because the files being fetched are always in the local machine.