### PR TITLE
Fix broken link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,6 @@ aw-server --testing
 
 You can also get a very decent API browser by browsing to `localhost:5600` after starting the server.
 
-There are also some API examples in the [documentation](http://activitywatch.readthedocs.io/en/latest/api.html).
+There are also some API examples in the [documentation](https://activitywatch.readthedocs.io/en/latest/api-reference.html).
 
 


### PR DESCRIPTION
Fixes a small issue I ran into while trying to find the API docs.