### PR TITLE
Disable threading in flask

### DIFF
--- a/aw_server/server.py
+++ b/aw_server/server.py
@@ -70,7 +70,7 @@ def _start(storage_method, host: str, port: int, testing: bool=False, cors_origi
     db = Datastore(storage_method, testing=testing)
     app.api = ServerAPI(db=db, testing=testing)
     try:
-        app.run(debug=testing, host=host, port=port, request_handler=FlaskLogHandler, use_reloader=False)
+        app.run(debug=testing, host=host, port=port, request_handler=FlaskLogHandler, use_reloader=False, threaded=False)
     except OSError as e:
         logger.error(str(e))
         raise e


### PR DESCRIPTION
Not tested at all, did this in the GitHub webui

Workaround so the sqlite datastore is only accessed from one thread.