### PR TITLE
Expose replace event endpoint

### DIFF
--- a/aw_server/api.py
+++ b/aw_server/api.py
@@ -152,9 +152,14 @@ class ServerAPI:
         return self.db[bucket_id].get_eventcount(start, end)
 
     @check_bucket_exists
-    def delete_event(self, bucket_id: str, event_id) -> bool:
+    def delete_event(self, bucket_id: str, event_id: int) -> bool:
         """Delete a single event from a bucket"""
         return self.db[bucket_id].delete(event_id)
+
+    @check_bucket_exists
+    def replace_event(self, bucket_id: str, event_id: int, event: Event) -> bool:
+        """Replace the specified event by a new one."""
+        return self.db[bucket_id].replace(event_id, event)
 
     @check_bucket_exists
     def heartbeat(self, bucket_id: str, heartbeat: Event, pulsetime: float) -> Event:

--- a/aw_server/rest.py
+++ b/aw_server/rest.py
@@ -203,6 +203,19 @@ class EventResource(Resource):
     #     events = current_app.api.get_events(bucket_id, limit=limit, start=start, end=end)
     #     return events, 200
 
+    @api.expect(event)
+    def put(self, bucket_id, event_id):
+        data = request.get_json()
+        logger.debug("Received put request for event with id '{}' in bucket '{}' and data: {}".format(event_id, bucket_id, data))
+
+        if isinstance(data, dict):
+            event = Event(**data)
+        else:
+            raise BadRequest("Invalid PUT data", "")
+
+        event = current_app.api.replace_event(bucket_id, event_id, event)
+        return event.to_json_dict() if event else None, 200
+
     @copy_doc(ServerAPI.delete_event)
     def delete(self, bucket_id, event_id):
         logger.debug("Received delete request for event with id '{}' in bucket '{}'".format(event_id, bucket_id))


### PR DESCRIPTION
This is the endpoint I'd propose for https://github.com/ActivityWatch/activitywatch/issues/71#issuecomment-506957056 , I can do it for the Rust version later if you agree on the API.

Missing parts: Test, explicit check if event_id does not exist (I assume it would cause a server error now). I'm not sure if I should bother with this if you plan to abandon this in spite of the Rust server?