### PR TITLE
Ignore API limit when using "Start" query (#232)

### DIFF
--- a/aw_server/rest.py
+++ b/aw_server/rest.py
@@ -152,7 +152,16 @@ class EventsResource(Resource):
     @copy_doc(ServerAPI.get_events)
     def get(self, bucket_id):
         args = request.args
-        limit = int(args["limit"]) if "limit" in args else 100
+        
+        if "limit" in args:
+            limit = int(args["limit"])
+        elif "start" in args:
+            # If a start object is defined in query string, 
+            # return all associated events.
+            limit = -1
+        else:
+            limit = 100
+        
         start = iso8601.parse_date(args["start"]) if "start" in args else None
         end = iso8601.parse_date(args["end"]) if "end" in args else None
 

--- a/aw_server/rest.py
+++ b/aw_server/rest.py
@@ -152,16 +152,7 @@ class EventsResource(Resource):
     @copy_doc(ServerAPI.get_events)
     def get(self, bucket_id):
         args = request.args
-        
-        if "limit" in args:
-            limit = int(args["limit"])
-        elif "start" in args:
-            # If a start object is defined in query string, 
-            # return all associated events.
-            limit = -1
-        else:
-            limit = 100
-        
+        limit = int(args["limit"]) if "limit" in args else -1
         start = iso8601.parse_date(args["start"]) if "start" in args else None
         end = iso8601.parse_date(args["end"]) if "end" in args else None
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -51,5 +51,25 @@ def test_get_events(flask_client, bucket, benchmark):
         assert r.json
         assert len(r.json) == n_events
 
+def test_get_events_from_start_time(flask_client, bucket, benchmark):
+    """
+        Issue #232: When using a start parameter, ignore the 100 limit by default. 
+    """
+    n_events = 150
+    start_time = datetime.now() - timedelta(1)
+    for i in range(n_events):
+        now = datetime.now() - timedelta(1)
+        r = flask_client.post('/api/0/buckets/test/heartbeat?pulsetime=0'.format(bucket), json={'timestamp': now, 'duration': 0, 'data': {'random': random.random()}})
+        # print(r.json)
+        assert r.status_code == 200
+
+    @benchmark
+    def get_all_events_from_start_query():
+        r = flask_client.get('/api/0/buckets/test/events?start={}'.format(start_time.isoformat()))
+        # print(r.json)
+        assert r.status_code == 200
+        assert r.json
+        assert len(r.json) == n_events
+
 
 # TODO: Add benchmark for basic AFK-filtering query

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -56,6 +56,11 @@ def test_get_events(flask_client, bucket, benchmark):
         assert r.status_code == 200
         assert r.json
         assert len(r.json) == n_events
+
+        r = flask_client.get('/api/0/buckets/test/events?limit=10'.format(bucket))
+        assert r.status_code == 200
+        assert r.json
+        assert len(r.json) == 10
         
         r = flask_client.get('/api/0/buckets/test/events?limit=100'.format(bucket))
         assert r.status_code == 200


### PR DESCRIPTION
Addressing the issue reported here: 
https://github.com/ActivityWatch/activitywatch/issues/232

Included a test case that helped highlight the issue. If using a start time query, it would only return a subset of the events instead of the full event set fitting the filter parameters. 