### PR TITLE
BLOCKED(discussion ongoing): Default backend db to sqlite

### DIFF
--- a/aw_server/config.py
+++ b/aw_server/config.py
@@ -6,13 +6,13 @@ default_config = ConfigParser()
 default_config["server"] = {
     "host": "localhost",
     "port": "5600",
-    "storage": "peewee",
+    "storage": "sqlite",
     "cors_origins": ""
 }
 default_config["server-testing"] = {
     "host": "localhost",
     "port": "5666",
-    "storage": "peewee",
+    "storage": "sqlite",
     "cors_origins": ""
 }
 


### PR DESCRIPTION
We could notify users that sqlite is the only supported backend going forward, or we could migrate config files via a script.

@ErikBjare Do you have any input on which way we should approach making existing users migrate?
