### PR TITLE
api: Make insert event never return anything

### DIFF
--- a/aw_server/__about__.py
+++ b/aw_server/__about__.py
@@ -52,7 +52,7 @@ def detect_version():
     return basever + ".dev+unknown"
 
 
-__version__ = 'v0.10.dev+32e3624'
+__version__ = "v0.10.dev+32e3624"
 
 
 def assign_static_version():

--- a/aw_server/api.py
+++ b/aw_server/api.py
@@ -178,7 +178,7 @@ class ServerAPI:
         """Create events for a bucket. Can handle both single events and multiple ones.
 
         Returns the inserted event when a single event was inserted, otherwise None."""
-        return self.db[bucket_id].insert(events[0] if len(events) == 1 else events)
+        return self.db[bucket_id].insert(events)
 
     @check_bucket_exists
     def get_eventcount(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -168,9 +168,9 @@ def test_list_buckets(aw_client, bucket):
 
 def test_send_event(aw_client, bucket):
     event = Event(timestamp=datetime.now(tz=timezone.utc), data={"label": "test"})
-    recv_event = aw_client.send_event(bucket, event)
-    assert recv_event.id is not None
-    assert recv_event == event
+    aw_client.send_event(bucket, event)
+    recv_events = aw_client.get_events(bucket, limit=1)
+    assert recv_events == [event]
 
 
 def test_send_events(aw_client, bucket):


### PR DESCRIPTION
This feature has not been used since our very old replace_last code before heartbeats were a thing.

I came across this when trying to fix integration tests in the main activitywatch repository.

Depends on https://github.com/ActivityWatch/aw-client/pull/55