### PR TITLE
Fix a `404` error when loading the dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist
 static
 .*cache
 profiling
+venv
 
 # coverage stuff
 .coverage

--- a/aw_server/server.py
+++ b/aw_server/server.py
@@ -35,8 +35,8 @@ class AWFlask(Flask):
         storage_method=None,
         cors_origins=[],
         custom_static=dict(),
-        *args,
-        **kwargs
+        static_folder=static_folder,
+        static_url_path="",
     ):
         name = "aw-server"
         self.json_provider_class = CustomJSONProvider
@@ -44,7 +44,12 @@ class AWFlask(Flask):
         self.json_provider_class.compact = not testing
 
         # Initialize Flask
-        Flask.__init__(self, name, *args, **kwargs)
+        Flask.__init__(
+            self,
+            name,
+            static_folder=static_folder,
+            static_url_path=static_url_path,
+        )
         self.config["HOST"] = host  # needed for host-header check
         with self.app_context():
             _config_cors(cors_origins, testing)


### PR DESCRIPTION
This PR fixes the following issues:
- Fixes https://github.com/ActivityWatch/aw-server/issues/143
- Fixes https://github.com/ActivityWatch/activitywatch/issues/922

---

I added the missing parameters to the `AWFlask` class initialisation in the `_start()` method.
I also added the `venv` folder to the `.gitignore` file.

---

<sup>It definitely didn't take about 2 hours to figure out what's wrong :D</sup>