### PR TITLE
Fix ImportError when using newer Flask version

### DIFF
--- a/aw_server/custom_static.py
+++ b/aw_server/custom_static.py
@@ -23,11 +23,11 @@ Another parameter called "view" can be used if you want to create multiple visua
 
 from flask import (
     Blueprint,
-    escape,
     jsonify,
     send_from_directory,
 )
 
+from markupsafe import escape
 
 def get_custom_static_blueprint(custom_static_directories):
     custom_static_blueprint = Blueprint("custom_static", __name__, url_prefix="/")


### PR DESCRIPTION
Importing `escape` is deprecated after [Flask 2.3.0](https://flask.palletsprojects.com/en/stable/changes/#version-2-3-0).