### PR TITLE
feat: add Docker and PostgreSQL support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Ignore patterns for the build context (monorepo root)
+**/__pycache__
+**/*.pyc
+**/*.pyo
+**/*.pyd
+**/.Python
+env/
+venv/
+.venv/
+.git/
+.gitignore
+.dockerignore
+
+# Node
+**/node_modules
+**/npm-debug.log
+**/yarn-error.log
+
+# WebUI builds
+**/dist
+**/aw_server/static
+
+# IDEs
+.idea/
+.vscode/
+*.swp

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "aw-webui"]
 	path = aw-webui
-	url = https://github.com/ActivityWatch/aw-webui.git
+	url = https://github.com/Xceedanceconsulting/aw-webui.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,58 @@
+# syntax=docker/dockerfile:1
+
+# Stage 1: Build the WebUI
+FROM node:20-alpine AS frontend-builder
+
+WORKDIR /build
+
+# Copy WebUI source
+# Note: Context is the monorepo root
+COPY aw-server/aw-webui ./aw-server/aw-webui
+
+# Install dependencies and build
+WORKDIR /build/aw-server/aw-webui
+RUN npm ci && npm run build
+
+# Stage 2: Setup Python environment and run
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install system dependencies for Postgres adapter
+RUN apt-get update && apt-get install -y \
+    libpq-dev \
+    gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy and install aw-core (from root context)
+COPY aw-core /app/aw-core
+RUN pip install /app/aw-core
+
+# Copy and install aw-client (from root context)
+COPY aw-client /app/aw-client
+RUN pip install /app/aw-client
+
+# Copy aw-server source
+COPY aw-server /app/aw-server
+
+# Copy built WebUI assets to the static folder expected by aw-server
+COPY --from=frontend-builder /build/aw-server/aw-webui/dist /app/aw-server/aw_server/static
+
+# Install aw-server
+RUN pip install /app/aw-server
+
+# Cleanup source files to reduce image size (optional, but good practice)
+# We keep them if we want to run tests or run from source, but pip install installed them to site-packages.
+# We will run from the installed module.
+
+# Expose the default port
+EXPOSE 5600
+
+# Set the entrypoint
+# We use shell form to allow expansion of environment variables if needed, 
+# but exec form is better for signal handling. 
+# We'll default to the module execution.
+ENTRYPOINT ["python", "-m", "aw_server"]
+
+# Default command arguments (can be overridden)
+CMD ["--host", "0.0.0.0", "--storage", "postgres"]

--- a/aw_server/custom_static.py
+++ b/aw_server/custom_static.py
@@ -21,9 +21,9 @@ Another parameter called "view" can be used if you want to create multiple visua
 
 """
 
+from markupsafe import escape
 from flask import (
     Blueprint,
-    escape,
     jsonify,
     send_from_directory,
 )

--- a/aw_server/main.py
+++ b/aw_server/main.py
@@ -89,9 +89,19 @@ def parse_settings():
         dest="custom_static",
         help="The custom static directories. Format: watcher_name=path,watcher_name2=path2,...",
     )
+    # Postgres specific arguments
+    parser.add_argument("--pg-host", dest="pg_host", help="Postgres host")
+    parser.add_argument("--pg-port", dest="pg_port", type=int, help="Postgres port")
+    parser.add_argument("--pg-user", dest="pg_user", help="Postgres user")
+    parser.add_argument("--pg-password", dest="pg_password", help="Postgres password")
+    parser.add_argument(
+        "--pg-database", dest="pg_database", help="Postgres database name"
+    )
+
     args = parser.parse_args()
     if args.version:
         print(__version__)
+
         sys.exit(0)
 
     """ Parse config file """
@@ -114,7 +124,27 @@ def parse_settings():
     settings.cors_origins = [o for o in settings.cors_origins.split(",") if o]
 
     storage_methods = get_storage_methods()
-    storage_method = storage_methods[settings.storage]
+    storage_method_cls = storage_methods[settings.storage]
+
+    # Curry the storage method with the settings
+    # This is a bit of a hack, but it works because the storage methods accept kwargs
+    # and ignore the ones they don't need (or rather, we only pass relevant ones if we were cleaner)
+    # But since we want to pass these dynamically...
+
+    def storage_method(testing, **kwargs):
+        # Merge CLI args into kwargs
+        kwargs.update(
+            {
+                "host": getattr(settings, "pg_host", None),
+                "port": getattr(settings, "pg_port", None),
+                "user": getattr(settings, "pg_user", None),
+                "password": getattr(settings, "pg_password", None),
+                "database": getattr(settings, "pg_database", None),
+            }
+        )
+        # Filter out None values
+        kwargs = {k: v for k, v in kwargs.items() if v is not None}
+        return storage_method_cls(testing=testing, **kwargs)
 
     return settings, storage_method
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.8'
+
+services:
+  aw-server:
+    build:
+      context: ..
+      dockerfile: aw-server/Dockerfile
+    ports:
+      - "5600:5600"
+    depends_on:
+      - aw-postgres
+    command: >
+      --host 0.0.0.0
+      --storage postgres
+      --pg-host aw-postgres
+      --pg-port 5432
+      --pg-user aw
+      --pg-password aw-secure
+      --pg-database aw
+    restart: unless-stopped
+
+  aw-postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: aw
+      POSTGRES_PASSWORD: aw-secure
+      POSTGRES_DB: aw
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    restart: unless-stopped
+    ports:
+      # Optional: Expose Postgres to host for debugging
+      - "5433:5432"
+
+volumes:
+  postgres-data:


### PR DESCRIPTION
## Summary
This PR adds Docker containerization support and enables the use of PostgreSQL as a storage backend.

### Changes
1. **PostgreSQL Support**:
   - Added CLI arguments for Postgres connection details (`--storage postgres`, `--pg-host`, `--pg-user`, etc.).
   - Implemented Postgres connection logic using `peewee` and `psycopg2`.

2. **Docker Support**:
   - Added `Dockerfile` (multi-stage build for WebUI and Server).
   - Added `docker-compose.yml` to spin up `aw-server` and `aw-postgres` (Postgres 16).
   - Added `.dockerignore`.

3. **Submodule Update**:
   - Updated `aw-webui` submodule. 
   - **Note**: Currently points to a fork (`Xceedanceconsulting/aw-webui`) to include a fix for builds failing when `.git` context is missing (see dependent PR).

## Dependencies
- Depends on [ActivityWatch/aw-webui#743](https://github.com/ActivityWatch/aw-webui/pull/743) for the `vue.config.js` fix.

## Testing
- Verified `docker-compose up` builds and runs successfully.
- Verified data persistence in Postgres backend.
- Verified WebUI accessibility.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds Docker and PostgreSQL support with CLI arguments, connection logic, and Docker setup for `aw-server` and `aw-postgres`.
> 
>   - **PostgreSQL Support**:
>     - Added CLI arguments for Postgres connection in `aw_server/main.py`.
>     - Implemented connection logic using `peewee` and `psycopg2` in `aw_server/main.py`.
>   - **Docker Support**:
>     - Added `Dockerfile` for multi-stage build of WebUI and Server.
>     - Added `docker-compose.yml` to set up `aw-server` and `aw-postgres`.
>     - Added `.dockerignore` to exclude unnecessary files from Docker context.
>   - **Submodule Update**:
>     - Updated `aw-webui` submodule to a fork for build fix.
>   - **Testing**:
>     - Verified `docker-compose up` builds and runs successfully.
>     - Confirmed data persistence in Postgres and WebUI accessibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-server&utm_source=github&utm_medium=referral)<sup> for 2a78757f94b832e37591fea641c0487af23cd488. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->