### PR TITLE
fix(test): resolve flaky test_midnight_heartbeats boundary condition

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -272,9 +272,7 @@ def test_midnight_heartbeats(aw_client, bucket):
     # the 23:50 start. Use a small offset to avoid boundary ambiguity where
     # events ending exactly at midnight could be included by the >= condition.
     query_start = midnight + timedelta(minutes=10, milliseconds=1)
-    recv_events_after_midnight = aw_client.get_events(
-        bucket, start=query_start
-    )
+    recv_events_after_midnight = aw_client.get_events(bucket, start=query_start)
     pprint(recv_events_after_midnight)
     assert len(recv_events_after_midnight) == int(len(recv_events_merged) / 2)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -253,7 +253,11 @@ def test_midnight(aw_client, bucket):
 
 def test_midnight_heartbeats(aw_client, bucket):
     now = datetime.now(tz=timezone.utc) - timedelta(days=1)
-    midnight = now.replace(hour=23, minute=50)
+    # Zero out seconds/microseconds for deterministic midnight boundary.
+    # Without this, residual microseconds cause non-deterministic boundary
+    # matching when querying events around midnight (the endtime >= start_query
+    # condition can include/exclude boundary events depending on microseconds).
+    midnight = now.replace(hour=23, minute=50, second=0, microsecond=0)
     events = _create_periodic_events(20, start=midnight, delta=timedelta(minutes=1))
 
     label_ring = ["1", "1", "2", "3", "4"]
@@ -264,8 +268,12 @@ def test_midnight_heartbeats(aw_client, bucket):
     recv_events_merged = aw_client.get_events(bucket, limit=-1)
     assert len(recv_events_merged) == 4 / 5 * len(events)
 
+    # Query from midnight (00:00), which is exactly midnight + 10 minutes from
+    # the 23:50 start. Use a small offset to avoid boundary ambiguity where
+    # events ending exactly at midnight could be included by the >= condition.
+    query_start = midnight + timedelta(minutes=10, milliseconds=1)
     recv_events_after_midnight = aw_client.get_events(
-        bucket, start=midnight + timedelta(minutes=10)
+        bucket, start=query_start
     )
     pprint(recv_events_after_midnight)
     assert len(recv_events_after_midnight) == int(len(recv_events_merged) / 2)


### PR DESCRIPTION
## Summary

Fixes the intermittently failing `test_midnight_heartbeats` test (seen in ActivityWatch/activitywatch#1211 CI as `assert 9 == 8`).

**Root cause**: The test creates events spanning midnight, then queries events "after midnight." Two issues caused non-deterministic results:

1. `midnight` retained residual microseconds from `datetime.now()`, making the exact boundary non-deterministic across runs
2. Event 9 (at 23:59 with 1-min duration) has `endtime` exactly at midnight, and the server's `endtime >= start_query` SQL condition sometimes includes it

**Fix**:
- Zero out seconds/microseconds on the start timestamp for deterministic boundaries
- Add a 1ms offset to the query start to avoid the ambiguous boundary where events ending exactly at midnight could be included by the `>=` condition

## Test plan

- [ ] Existing `test_midnight_heartbeats` passes consistently (no more flaky failures)
- [ ] Other midnight tests unaffected
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes flaky `test_midnight_heartbeats` by ensuring deterministic timestamp boundaries and adding a 1ms offset to avoid boundary ambiguity.
> 
>   - **Behavior**:
>     - Fixes flaky `test_midnight_heartbeats` in `test_client.py` by ensuring deterministic timestamp boundaries.
>     - Zeroes out seconds/microseconds in `midnight` to prevent non-deterministic boundary matching.
>     - Adds 1ms offset to `query_start` to avoid including events ending exactly at midnight.
>   - **Test Plan**:
>     - Ensures `test_midnight_heartbeats` passes consistently.
>     - Confirms other midnight tests remain unaffected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-server&utm_source=github&utm_medium=referral)<sup> for 7eeec25eb85554fb46c27fc37ad00dcc1bdb3fb8. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->