### PR TITLE
fix(api): return inserted event with server-assigned ID from single insert; return [] from bulk

### DIFF
--- a/aw_server/api.py
+++ b/aw_server/api.py
@@ -228,11 +228,19 @@ class ServerAPI:
         return events
 
     @check_bucket_exists
-    def create_events(self, bucket_id: str, events: List[Event]) -> Optional[Event]:
+    def create_events(self, bucket_id: str, events: List[Event]) -> List[Event]:
         """Create events for a bucket. Can handle both single events and multiple ones.
 
-        Returns the inserted event when a single event was inserted, otherwise None."""
-        return self.db[bucket_id].insert(events)
+        Always returns a list of inserted events (matching aw-server-rust behavior).
+        For single events, the returned event includes the server-assigned ID.
+        For bulk inserts, events may not have IDs due to storage limitations."""
+        if len(events) == 1:
+            # Pass as single Event so Bucket.insert uses insert_one (returns Event with ID)
+            inserted = self.db[bucket_id].insert(events[0])
+            return [inserted]
+        else:
+            self.db[bucket_id].insert(events)
+            return events
 
     @check_bucket_exists
     def get_eventcount(

--- a/aw_server/api.py
+++ b/aw_server/api.py
@@ -229,11 +229,19 @@ class ServerAPI:
         return events
 
     @check_bucket_exists
-    def create_events(self, bucket_id: str, events: List[Event]) -> Optional[Event]:
+    def create_events(self, bucket_id: str, events: List[Event]) -> List[Event]:
         """Create events for a bucket. Can handle both single events and multiple ones.
 
-        Returns the inserted event when a single event was inserted, otherwise None."""
-        return self.db[bucket_id].insert(events)
+        Always returns a list of inserted events (matching aw-server-rust behavior).
+        For single events, the returned event includes the server-assigned ID.
+        For bulk inserts, events may not have IDs due to storage limitations."""
+        if len(events) == 1:
+            # Pass as single Event so Bucket.insert uses insert_one (returns Event with ID)
+            inserted = self.db[bucket_id].insert(events[0])
+            return [inserted]
+        else:
+            self.db[bucket_id].insert(events)
+            return events
 
     @check_bucket_exists
     def get_eventcount(

--- a/aw_server/api.py
+++ b/aw_server/api.py
@@ -234,14 +234,14 @@ class ServerAPI:
 
         Always returns a list of inserted events (matching aw-server-rust behavior).
         For single events, the returned event includes the server-assigned ID.
-        For bulk inserts, events may not have IDs due to storage limitations."""
+        For bulk inserts, returns empty list (events may not have IDs without a response-SQL roundtrip)."""
         if len(events) == 1:
             # Pass as single Event so Bucket.insert uses insert_one (returns Event with ID)
             inserted = self.db[bucket_id].insert(events[0])
             return [inserted]
         else:
             self.db[bucket_id].insert(events)
-            return events
+            return []
 
     @check_bucket_exists
     def get_eventcount(

--- a/aw_server/api.py
+++ b/aw_server/api.py
@@ -234,7 +234,8 @@ class ServerAPI:
 
         Always returns a list of inserted events (matching aw-server-rust behavior).
         For single events, the returned event includes the server-assigned ID.
-        For bulk inserts, returns empty list (events may not have IDs without a response-SQL roundtrip)."""
+        For bulk inserts, returns empty list (events may not have IDs without a response-SQL roundtrip).
+        """
         if len(events) == 1:
             # Pass as single Event so Bucket.insert uses insert_one (returns Event with ID)
             inserted = self.db[bucket_id].insert(events[0])

--- a/aw_server/rest.py
+++ b/aw_server/rest.py
@@ -225,8 +225,8 @@ class EventsResource(Resource):
         else:
             raise BadRequest("Invalid POST data", "")
 
-        event = current_app.api.create_events(bucket_id, events)
-        return event.to_json_dict() if event else None, 200
+        events = current_app.api.create_events(bucket_id, events)
+        return [e.to_json_dict() for e in events], 200
 
 
 @api.route("/0/buckets/<string:bucket_id>/events/count")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -88,4 +88,48 @@ def test_get_events(flask_client, bucket, benchmark):
         assert len(r.json) == n_events
 
 
+def test_insert_event_returns_list(flask_client, bucket):
+    """Test that POST /events returns a list of events with IDs (matching aw-server-rust)."""
+    now = datetime.now()
+    event_data = {"timestamp": now.isoformat(), "duration": 0, "data": {"label": "test"}}
+
+    # Single event as list
+    r = flask_client.post(
+        f"/api/0/buckets/{bucket}/events",
+        json=[event_data],
+    )
+    assert r.status_code == 200
+    assert isinstance(r.json, list), f"Expected list, got {type(r.json)}"
+    assert len(r.json) == 1
+    assert r.json[0]["id"] is not None
+    assert r.json[0]["data"] == {"label": "test"}
+
+    # Single event as dict (legacy format)
+    r = flask_client.post(
+        f"/api/0/buckets/{bucket}/events",
+        json=event_data,
+    )
+    assert r.status_code == 200
+    assert isinstance(r.json, list), f"Expected list, got {type(r.json)}"
+    assert len(r.json) == 1
+    assert r.json[0]["id"] is not None
+
+
+def test_insert_events_returns_list(flask_client, bucket):
+    """Test that POST /events with multiple events returns a list."""
+    now = datetime.now()
+    events_data = [
+        {"timestamp": (now - timedelta(hours=i)).isoformat(), "duration": 0, "data": {"label": f"test-{i}"}}
+        for i in range(3)
+    ]
+
+    r = flask_client.post(
+        f"/api/0/buckets/{bucket}/events",
+        json=events_data,
+    )
+    assert r.status_code == 200
+    assert isinstance(r.json, list), f"Expected list, got {type(r.json)}"
+    assert len(r.json) == 3
+
+
 # TODO: Add benchmark for basic AFK-filtering query

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -91,7 +91,11 @@ def test_get_events(flask_client, bucket, benchmark):
 def test_insert_event_returns_list(flask_client, bucket):
     """Test that POST /events returns a list of events with IDs (matching aw-server-rust)."""
     now = datetime.now()
-    event_data = {"timestamp": now.isoformat(), "duration": 0, "data": {"label": "test"}}
+    event_data = {
+        "timestamp": now.isoformat(),
+        "duration": 0,
+        "data": {"label": "test"},
+    }
 
     # Single event as list
     r = flask_client.post(
@@ -119,7 +123,11 @@ def test_insert_events_returns_list(flask_client, bucket):
     """Test that POST /events with multiple events returns a list."""
     now = datetime.now()
     events_data = [
-        {"timestamp": (now - timedelta(hours=i)).isoformat(), "duration": 0, "data": {"label": f"test-{i}"}}
+        {
+            "timestamp": (now - timedelta(hours=i)).isoformat(),
+            "duration": 0,
+            "data": {"label": f"test-{i}"},
+        }
         for i in range(3)
     ]
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -88,6 +88,50 @@ def test_get_events(flask_client, bucket, benchmark):
         assert len(r.json) == n_events
 
 
+def test_insert_event_returns_list(flask_client, bucket):
+    """Test that POST /events returns a list of events with IDs (matching aw-server-rust)."""
+    now = datetime.now()
+    event_data = {"timestamp": now.isoformat(), "duration": 0, "data": {"label": "test"}}
+
+    # Single event as list
+    r = flask_client.post(
+        f"/api/0/buckets/{bucket}/events",
+        json=[event_data],
+    )
+    assert r.status_code == 200
+    assert isinstance(r.json, list), f"Expected list, got {type(r.json)}"
+    assert len(r.json) == 1
+    assert r.json[0]["id"] is not None
+    assert r.json[0]["data"] == {"label": "test"}
+
+    # Single event as dict (legacy format)
+    r = flask_client.post(
+        f"/api/0/buckets/{bucket}/events",
+        json=event_data,
+    )
+    assert r.status_code == 200
+    assert isinstance(r.json, list), f"Expected list, got {type(r.json)}"
+    assert len(r.json) == 1
+    assert r.json[0]["id"] is not None
+
+
+def test_insert_events_returns_list(flask_client, bucket):
+    """Test that POST /events with multiple events returns a list."""
+    now = datetime.now()
+    events_data = [
+        {"timestamp": (now - timedelta(hours=i)).isoformat(), "duration": 0, "data": {"label": f"test-{i}"}}
+        for i in range(3)
+    ]
+
+    r = flask_client.post(
+        f"/api/0/buckets/{bucket}/events",
+        json=events_data,
+    )
+    assert r.status_code == 200
+    assert isinstance(r.json, list), f"Expected list, got {type(r.json)}"
+    assert len(r.json) == 3
+
+
 # TODO: Add benchmark for basic AFK-filtering query
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -137,7 +137,7 @@ def test_insert_events_returns_list(flask_client, bucket):
     )
     assert r.status_code == 200
     assert isinstance(r.json, list), f"Expected list, got {type(r.json)}"
-    assert len(r.json) == 3
+    assert len(r.json) == 0
 
 
 # TODO: Add benchmark for basic AFK-filtering query


### PR DESCRIPTION
## What and why

`POST /api/0/buckets/{id}/events` previously returned inconsistent responses:
- single event → bare event dict (no list wrapping)
- bulk events → `null`

This mismatches aw-server-rust (which always returns a list) and blocked aw-client from
surfacing server-assigned event IDs to callers (ActivityWatch/aw-client#103).

**This PR fixes the Python server response format:**

| Case | Before | After |
|------|--------|-------|
| Single event | `{...}` (dict, no ID guarantee) | `[{"id": 1, ...}]` (list with server-assigned ID) |
| Bulk events | `null` | `[]` (empty list — SQLite bulk insert can't return IDs efficiently) |

The single-event path uses `insert_one()` which does return the assigned ID;
the bulk path returns an empty list rather than the input events (which would be
misleading since they lack IDs).

## Changes

- `api.py`: `create_events()` returns `List[Event]` — `insert_one` for single (gets ID), `insert_many` for bulk (returns `[]`)
- `rest.py`: serializes response as a list of event dicts
- `tests/test_server.py`: two new tests verifying list response for single and bulk inserts

## Unblocks

ActivityWatch/aw-client#103 — which adds `insert_event()` → `Optional[Event]` return value
so callers can retrieve the server-assigned ID for subsequent update/delete.
