### PR TITLE
fix: reject heartbeats on lock timeout instead of proceeding unsafely

### DIFF
--- a/aw_server/rest.py
+++ b/aw_server/rest.py
@@ -291,11 +291,12 @@ class HeartbeatResource(Resource):
         # This lock is meant to ensure that only one heartbeat is processed at a time,
         # as the heartbeat function is not thread-safe.
         # This should maybe be moved into the api.py file instead (but would be very messy).
-        aquired = self.lock.acquire(timeout=1)
-        if not aquired:
+        acquired = self.lock.acquire(timeout=10)
+        if not acquired:
             logger.warning(
-                "Heartbeat lock could not be aquired within a reasonable time, this likely indicates a bug."
+                "Heartbeat lock could not be acquired within timeout, rejecting request."
             )
+            return {"message": "Server busy, try again later"}, 503
         try:
             event = current_app.api.heartbeat(bucket_id, heartbeat, pulsetime)
         finally:

--- a/aw_server/rest.py
+++ b/aw_server/rest.py
@@ -271,8 +271,12 @@ class EventResource(Resource):
 
 @api.route("/0/buckets/<string:bucket_id>/heartbeat")
 class HeartbeatResource(Resource):
+    # Class-level lock shared across all instances.
+    # Flask-RESTX creates a new Resource instance per request, so an
+    # instance-level lock would provide no mutual exclusion.
+    lock = Lock()
+
     def __init__(self, *args, **kwargs):
-        self.lock = Lock()
         super().__init__(*args, **kwargs)
 
     @api.expect(event, validate=True)


### PR DESCRIPTION
## Summary
- Return 503 when heartbeat lock can't be acquired, instead of proceeding without thread safety
- Increase lock timeout from 1s to 10s to reduce spurious rejections

## Problem
The heartbeat lock handling had a bug: when `self.lock.acquire(timeout=1)` timed out, the code would:
1. **Proceed to execute `heartbeat()` without holding the lock** — causing concurrent SQLite access
2. **Call `self.lock.release()` in `finally`** — releasing a lock this thread doesn't own

This led to frequent `database is locked` errors and 500 responses, which caused watchers to retry, amplifying the problem.

## Fix
- If the lock can't be acquired within 10s, return HTTP 503 ("Server busy") so the client retries cleanly
- The longer timeout reduces spurious rejections under normal load

## Evidence from production logs
```
peewee.OperationalError: database is locked
500 (127.0.0.1): POST /api/0/buckets/aw-watcher-window_.../heartbeat
```
~4000 such errors in a 21-day session, with 9000 queued retry databases in aw-client.

## Test plan
- [ ] Existing tests pass
- [ ] Under concurrent heartbeat load, no "database is locked" errors
- [ ] Lock timeout returns 503 instead of crashing

See also: ActivityWatch/aw-core PR for enabling WAL mode (the complementary fix)